### PR TITLE
Use builtin group 'admin' and not 'admins'.

### DIFF
--- a/security/basic/a-mq-7/etc/artemis-roles.properties
+++ b/security/basic/a-mq-7/etc/artemis-roles.properties
@@ -14,6 +14,6 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
-admins=admin
+admin=admin
 users=user,admin
 guests=guest,admin

--- a/security/basic/a-mq-7/etc/artemis.profile
+++ b/security/basic/a-mq-7/etc/artemis.profile
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# ALERT: Edit these to match your installation.
+
 ARTEMIS_HOME='/opt/rh/A-MQ7-7.0.0.ER11-redhat-1'
 ARTEMIS_INSTANCE='/Users/dejanb/workspace/oss/amq-migration/security/basic/a-mq-7'
 

--- a/security/basic/a-mq-7/etc/broker.xml
+++ b/security/basic/a-mq-7/etc/broker.xml
@@ -92,15 +92,15 @@ under the License.
 
       <security-settings>
          <security-setting match="jms.queue.#">
-            <permission type="createNonDurableQueue" roles="admins"/>
-            <permission type="deleteNonDurableQueue" roles="admins"/>
-            <permission type="createDurableQueue" roles="admins"/>
-            <permission type="deleteDurableQueue" roles="admins"/>
-            <permission type="consume" roles="admins"/>
-            <permission type="browse" roles="admins"/>
-            <permission type="send" roles="admins"/>
+            <permission type="createNonDurableQueue" roles="admin"/>
+            <permission type="deleteNonDurableQueue" roles="admin"/>
+            <permission type="createDurableQueue" roles="admin"/>
+            <permission type="deleteDurableQueue" roles="admin"/>
+            <permission type="consume" roles="admin"/>
+            <permission type="browse" roles="admin"/>
+            <permission type="send" roles="admin"/>
             <!-- we need this otherwise ./artemis data imp wouldn't work -->
-            <permission type="manage" roles="admins"/>
+            <permission type="manage" roles="admin"/>
          </security-setting>
 
          <security-setting match="jms.queue.USERS.#">


### PR DESCRIPTION
Using 'admins' prevents console login and consume client 'admin'
is treated as user 'null'.